### PR TITLE
incorrect value assignment rectified

### DIFF
--- a/Runtime/Interaction/HPUIEvents.cs
+++ b/Runtime/Interaction/HPUIEvents.cs
@@ -182,7 +182,7 @@ namespace ubco.ovilab.HPUI.Interaction
             CumilativeDistance = cumilativeDistance;
             DeltaDirection = deltaDirection;
             CurrentTrackingInteractable = currentTrackingInteractable;
-            CurrentTrackingInteractablePoint = CurrentTrackingInteractablePoint;
+            CurrentTrackingInteractablePoint = currentTrackingInteractablePoint;
         }
     }
 


### PR DESCRIPTION
was always setting the point to itself, so the default value of 0,0