### PR TITLE
fixed active in hierarchy gameobject reference

### DIFF
--- a/Runtime/Interaction/HPUIInteractor.cs
+++ b/Runtime/Interaction/HPUIInteractor.cs
@@ -397,7 +397,7 @@ namespace ubco.ovilab.HPUI.Interaction
         /// <inheritdoc />
         protected void OnValidate()
         {
-            if (Application.isPlaying && activeInHierarchy)
+            if (Application.isPlaying && gameObject.activeInHierarchy)
             {
                 UpdateLogic();
                 UpdateVisuals();


### PR DESCRIPTION
throwing an error in unity if you don't do this