### PR TITLE
ConeRayAnglesEditor Freaking Out

### DIFF
--- a/Runtime/Components/EstimateConeRayAngles.cs
+++ b/Runtime/Components/EstimateConeRayAngles.cs
@@ -23,7 +23,7 @@ namespace ubco.ovilab.HPUI.Components
 
         [SerializeField]
         [Tooltip("Interactable segment pairs.")]
-        private List<ConeRayAnglesEstimationPair> interactableToSegmentMapping;
+        private List<ConeRayAnglesEstimationPair> interactableToSegmentMapping = new();
 
         /// <summary>
         /// List of interactable to segment mappaing pairs. The list is expected to have all segments.


### PR DESCRIPTION
The editor is freaking out with the error 

```ArgumentNullException: Value cannot be null.
Parameter name: source
System.Linq.Enumerable.Select[TSource,TResult] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] selector) (at <df4e462ab02c4b6493ccedf77f247b33>:0)
ubco.ovilab.HPUI.Editor.EstimateConeRayAnglesEditor.OnInspectorGUI () (at ./Packages/HPUI-Core/Editor/EstimateConeRayAnglesEditor.cs:55)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass79_0.<CreateInspectorElementUsingIMGUI>b__0 () (at <e6ff5fa81f7b4f289fd2b129b5dcbaee>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```

Steps to reproduce:
Create New Scene
Attach component to any gameobject

This kinda fixes it. Have a look if there might be other issues here