### PR TITLE
Caching Direction Calculation

### DIFF
--- a/Runtime/Interaction/HPUIInteractorConeRayAngles.cs
+++ b/Runtime/Interaction/HPUIInteractorConeRayAngles.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Unity.XR.CoreUtils.Collections;
 using UnityEngine;
 using UnityEngine.XR.Hands;
 
@@ -8,39 +7,10 @@ namespace ubco.ovilab.HPUI.Interaction
     /// <summary>
     /// Contains the angles for the cone ray cast to be used with the <see cref="HPUIInteractor"/>.
     /// </summary>
-    [CreateAssetMenu(fileName = "HPUIInteractorConeRayAngles", menuName = "HPUI/HPUI Interactor Cone Ray Angles",
-        order = 1)]
-    public class HPUIInteractorConeRayAngles : ScriptableObject
+    [CreateAssetMenu(fileName = "HPUIInteractorConeRayAngles", menuName = "HPUI/HPUI Interactor Cone Ray Angles", order = 1)]
+    public class HPUIInteractorConeRayAngles: ScriptableObject
     {
-        public SerializableDictionary<XRHandJointID, List<Vector3>> RightHandAngles
-        {
-            get
-            {
-                //Not the ideal way to validate but good enough ¯\_(ツ)_/¯
-                if (rightHandAngles.Count == joints.Count)
-                {
-                    return rightHandAngles;
-                }
-                CacheAngles();
-                return rightHandAngles;
-            }
-        }
-        
-        public SerializableDictionary<XRHandJointID, List<Vector3>> LeftHandAngles
-        {
-            get
-            {
-                //Not the ideal way to validate but good enough ¯\_(ツ)_/¯
-                if (leftHandAngles.Count == joints.Count)
-                {
-                    return leftHandAngles;
-                }
-                CacheAngles();
-                return leftHandAngles;
-            }
-        }
-        
-        public Dictionary<XRHandJointID, List<HPUIInteractorRayAngle>> ActiveFingerAngles; 
+        public Dictionary<XRHandJointID, List<HPUIInteractorRayAngle>> ActiveFingerAngles;
         // TODO: Cite source!
         // These are computed based on data collected during studies
         public List<HPUIInteractorRayAngle> IndexDistalAngles = new List<HPUIInteractorRayAngle>();
@@ -56,27 +26,6 @@ namespace ubco.ovilab.HPUI.Interaction
         public List<HPUIInteractorRayAngle> LittleIntermediateAngles = new List<HPUIInteractorRayAngle>();
         public List<HPUIInteractorRayAngle> LittleProximalAngles = new List<HPUIInteractorRayAngle>();
 
-        [SerializeField] private SerializableDictionary<XRHandJointID, List<Vector3>> rightHandAngles = new();
-        [SerializeField] private SerializableDictionary<XRHandJointID, List<Vector3>> leftHandAngles = new();
-        
-        
-        private List<XRHandJointID> joints = new()
-        {
-            XRHandJointID.IndexProximal,
-            XRHandJointID.IndexIntermediate,
-            XRHandJointID.IndexDistal,
-            XRHandJointID.MiddleProximal,
-            XRHandJointID.MiddleIntermediate,
-            XRHandJointID.MiddleDistal,
-            XRHandJointID.RingProximal,
-            XRHandJointID.RingIntermediate,
-            XRHandJointID.RingDistal,
-            XRHandJointID.LittleProximal,
-            XRHandJointID.LittleIntermediate,
-            XRHandJointID.LittleDistal
-        };
-
-        
 
         public HPUIInteractorConeRayAngles()
         {
@@ -96,45 +45,7 @@ namespace ubco.ovilab.HPUI.Interaction
                 { XRHandJointID.LittleDistal, LittleDistalAngles }
             };
         }
-
-        public void CacheAngles()
-        {
-            rightHandAngles.Clear();
-            leftHandAngles.Clear();
-            foreach (XRHandJointID joint in joints)
-            {
-                Debug.Log("Caching angles");
-                List<HPUIInteractorRayAngle> jointAngles = joint switch
-                {
-                    XRHandJointID.IndexProximal => IndexProximalAngles,
-                    XRHandJointID.IndexIntermediate => IndexIntermediateAngles,
-                    XRHandJointID.IndexDistal => IndexDistalAngles,
-                    XRHandJointID.MiddleProximal => MiddleProximalAngles,
-                    XRHandJointID.MiddleIntermediate => MiddleIntermediateAngles,
-                    XRHandJointID.MiddleDistal => MiddleDistalAngles,
-                    XRHandJointID.RingProximal => RingProximalAngles,
-                    XRHandJointID.RingIntermediate => RingIntermediateAngles,
-                    XRHandJointID.RingDistal => RingDistalAngles,
-                    XRHandJointID.LittleProximal => LittleProximalAngles,
-                    XRHandJointID.LittleIntermediate => LittleIntermediateAngles,
-                    XRHandJointID.LittleDistal => LittleDistalAngles,
-                    _ => throw new System.InvalidOperationException($"Unknown joint,")
-                };
-                
-                List<Vector3> processedAnglesRight = new();
-                List<Vector3> processedAnglesLeft = new();
-                
-                foreach (HPUIInteractorRayAngle angleData in jointAngles)
-                {
-                    processedAnglesRight.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
-                    processedAnglesLeft.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
-                }
-                
-                rightHandAngles.Add(joint, processedAnglesRight);
-                leftHandAngles.Add(joint, processedAnglesLeft);
-            }
-        }
     }
 
 }
- 
+

--- a/Runtime/Interaction/HPUIInteractorConeRayAngles.cs
+++ b/Runtime/Interaction/HPUIInteractorConeRayAngles.cs
@@ -1,17 +1,48 @@
 using System.Collections.Generic;
+using Unity.XR.CoreUtils.Collections;
 using UnityEngine;
+using UnityEngine.XR.Hands;
 
 namespace ubco.ovilab.HPUI.Interaction
 {
     /// <summary>
     /// Contains the angles for the cone ray cast to be used with the <see cref="HPUIInteractor"/>.
     /// </summary>
-    [CreateAssetMenu(fileName = "HPUIInteractorConeRayAngles", menuName = "HPUI/HPUI Interactor Cone Ray Angles", order = 1)]
-    public class HPUIInteractorConeRayAngles: ScriptableObject
+    [CreateAssetMenu(fileName = "HPUIInteractorConeRayAngles", menuName = "HPUI/HPUI Interactor Cone Ray Angles",
+        order = 1)]
+    public class HPUIInteractorConeRayAngles : ScriptableObject
     {
+        public SerializableDictionary<XRHandJointID, List<Vector3>> RightHandAngles
+        {
+            get
+            {
+                //Not the ideal way to validate but good enough ¯\_(ツ)_/¯
+                if (rightHandAngles.Count == joints.Count)
+                {
+                    return rightHandAngles;
+                }
+                CacheAngles();
+                return rightHandAngles;
+            }
+        }
+        
+        public SerializableDictionary<XRHandJointID, List<Vector3>> LeftHandAngles
+        {
+            get
+            {
+                //Not the ideal way to validate but good enough ¯\_(ツ)_/¯
+                if (leftHandAngles.Count == joints.Count)
+                {
+                    return leftHandAngles;
+                }
+                CacheAngles();
+                return leftHandAngles;
+            }
+        }
+        
+        public Dictionary<XRHandJointID, List<HPUIInteractorRayAngle>> ActiveFingerAngles; 
         // TODO: Cite source!
         // These are computed based on data collected during studies
-
         public List<HPUIInteractorRayAngle> IndexDistalAngles = new List<HPUIInteractorRayAngle>();
         public List<HPUIInteractorRayAngle> IndexIntermediateAngles = new List<HPUIInteractorRayAngle>();
         public List<HPUIInteractorRayAngle> IndexProximalAngles = new List<HPUIInteractorRayAngle>();
@@ -24,6 +55,86 @@ namespace ubco.ovilab.HPUI.Interaction
         public List<HPUIInteractorRayAngle> LittleDistalAngles = new List<HPUIInteractorRayAngle>();
         public List<HPUIInteractorRayAngle> LittleIntermediateAngles = new List<HPUIInteractorRayAngle>();
         public List<HPUIInteractorRayAngle> LittleProximalAngles = new List<HPUIInteractorRayAngle>();
+
+        [SerializeField] private SerializableDictionary<XRHandJointID, List<Vector3>> rightHandAngles = new();
+        [SerializeField] private SerializableDictionary<XRHandJointID, List<Vector3>> leftHandAngles = new();
+        
+        
+        private List<XRHandJointID> joints = new()
+        {
+            XRHandJointID.IndexProximal,
+            XRHandJointID.IndexIntermediate,
+            XRHandJointID.IndexDistal,
+            XRHandJointID.MiddleProximal,
+            XRHandJointID.MiddleIntermediate,
+            XRHandJointID.MiddleDistal,
+            XRHandJointID.RingProximal,
+            XRHandJointID.RingIntermediate,
+            XRHandJointID.RingDistal,
+            XRHandJointID.LittleProximal,
+            XRHandJointID.LittleIntermediate,
+            XRHandJointID.LittleDistal
+        };
+
+        
+
+        public HPUIInteractorConeRayAngles()
+        {
+            ActiveFingerAngles = new()
+            {
+                { XRHandJointID.IndexProximal, IndexProximalAngles },
+                { XRHandJointID.IndexIntermediate, IndexIntermediateAngles },
+                { XRHandJointID.IndexDistal, IndexDistalAngles },
+                { XRHandJointID.MiddleProximal, MiddleProximalAngles },
+                { XRHandJointID.MiddleIntermediate, MiddleIntermediateAngles },
+                { XRHandJointID.MiddleDistal, MiddleDistalAngles },
+                { XRHandJointID.RingProximal, RingProximalAngles },
+                { XRHandJointID.RingIntermediate, RingIntermediateAngles },
+                { XRHandJointID.RingDistal, RingDistalAngles },
+                { XRHandJointID.LittleProximal, LittleProximalAngles },
+                { XRHandJointID.LittleIntermediate, LittleIntermediateAngles },
+                { XRHandJointID.LittleDistal, LittleDistalAngles }
+            };
+        }
+
+        public void CacheAngles()
+        {
+            rightHandAngles.Clear();
+            leftHandAngles.Clear();
+            foreach (XRHandJointID joint in joints)
+            {
+                Debug.Log("Caching angles");
+                List<HPUIInteractorRayAngle> jointAngles = joint switch
+                {
+                    XRHandJointID.IndexProximal => IndexProximalAngles,
+                    XRHandJointID.IndexIntermediate => IndexIntermediateAngles,
+                    XRHandJointID.IndexDistal => IndexDistalAngles,
+                    XRHandJointID.MiddleProximal => MiddleProximalAngles,
+                    XRHandJointID.MiddleIntermediate => MiddleIntermediateAngles,
+                    XRHandJointID.MiddleDistal => MiddleDistalAngles,
+                    XRHandJointID.RingProximal => RingProximalAngles,
+                    XRHandJointID.RingIntermediate => RingIntermediateAngles,
+                    XRHandJointID.RingDistal => RingDistalAngles,
+                    XRHandJointID.LittleProximal => LittleProximalAngles,
+                    XRHandJointID.LittleIntermediate => LittleIntermediateAngles,
+                    XRHandJointID.LittleDistal => LittleDistalAngles,
+                    _ => throw new System.InvalidOperationException($"Unknown joint,")
+                };
+                
+                List<Vector3> processedAnglesRight = new();
+                List<Vector3> processedAnglesLeft = new();
+                
+                foreach (HPUIInteractorRayAngle angleData in jointAngles)
+                {
+                    processedAnglesRight.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
+                    processedAnglesLeft.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
+                }
+                
+                rightHandAngles.Add(joint, processedAnglesRight);
+                leftHandAngles.Add(joint, processedAnglesLeft);
+            }
+        }
     }
+
 }
  

--- a/Runtime/Interaction/HPUIInteractorFullRangeAngles.cs
+++ b/Runtime/Interaction/HPUIInteractorFullRangeAngles.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,41 +9,8 @@ namespace ubco.ovilab.HPUI.Interaction
     [CreateAssetMenu(fileName = "HPUIInteractorFullRangeAngles", menuName = "HPUI/HPUI Interactor Full Ray Angles", order = 1)]
     public class HPUIInteractorFullRangeAngles: ScriptableObject
     {
-        public List<Vector3> RightHandAngles
-        {
-            get
-            {
-                if (rightHandAngles.Count == angles.Count)
-                {
-                    return rightHandAngles;
-                }
-                else
-                {
-                    CacheAngles();
-                    return rightHandAngles;
-                }
-            }
-        } 
-        
-        public List<Vector3> LeftHandAngles
-        {
-            get
-            {
-                if (leftHandAngles.Count == angles.Count)
-                {
-                    return rightHandAngles;
-                }
-                else
-                {
-                    CacheAngles();
-                    return rightHandAngles;
-                }
-            }
-        }
-        
         public List<HPUIInteractorRayAngle> angles;
-        [SerializeField] private List<Vector3> rightHandAngles = new List<Vector3>();
-        [SerializeField] private List<Vector3> leftHandAngles = new List<Vector3>();
+
         // FIXME: Compute this on the fly and store it
 
         public static List<HPUIInteractorRayAngle> ComputeAngles(int maxAngle, int angleStep, float raySelectionThreshold)
@@ -81,23 +47,5 @@ namespace ubco.ovilab.HPUI.Interaction
             }
             return allAngles;
         }
-
-
-        private void Awake()
-        {
-            CacheAngles();
-        }
-
-        private void CacheAngles()
-        {
-            foreach (HPUIInteractorRayAngle angleData in angles)
-            {
-                rightHandAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
-                leftHandAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
-            }
-        }
-        
     }
-    
 }
- 

--- a/Runtime/Interaction/HPUIInteractorFullRangeAngles.cs
+++ b/Runtime/Interaction/HPUIInteractorFullRangeAngles.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -9,8 +10,41 @@ namespace ubco.ovilab.HPUI.Interaction
     [CreateAssetMenu(fileName = "HPUIInteractorFullRangeAngles", menuName = "HPUI/HPUI Interactor Full Ray Angles", order = 1)]
     public class HPUIInteractorFullRangeAngles: ScriptableObject
     {
+        public List<Vector3> RightHandAngles
+        {
+            get
+            {
+                if (rightHandAngles.Count == angles.Count)
+                {
+                    return rightHandAngles;
+                }
+                else
+                {
+                    CacheAngles();
+                    return rightHandAngles;
+                }
+            }
+        } 
+        
+        public List<Vector3> LeftHandAngles
+        {
+            get
+            {
+                if (leftHandAngles.Count == angles.Count)
+                {
+                    return rightHandAngles;
+                }
+                else
+                {
+                    CacheAngles();
+                    return rightHandAngles;
+                }
+            }
+        }
+        
         public List<HPUIInteractorRayAngle> angles;
-
+        [SerializeField] private List<Vector3> rightHandAngles = new List<Vector3>();
+        [SerializeField] private List<Vector3> leftHandAngles = new List<Vector3>();
         // FIXME: Compute this on the fly and store it
 
         public static List<HPUIInteractorRayAngle> ComputeAngles(int maxAngle, int angleStep, float raySelectionThreshold)
@@ -47,6 +81,23 @@ namespace ubco.ovilab.HPUI.Interaction
             }
             return allAngles;
         }
+
+
+        private void Awake()
+        {
+            CacheAngles();
+        }
+
+        private void CacheAngles()
+        {
+            foreach (HPUIInteractorRayAngle angleData in angles)
+            {
+                rightHandAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
+                leftHandAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
+            }
+        }
+        
     }
+    
 }
  

--- a/Runtime/Interaction/HPUIInteractorRayAngle.cs
+++ b/Runtime/Interaction/HPUIInteractorRayAngle.cs
@@ -87,6 +87,29 @@ namespace ubco.ovilab.HPUI.Interaction
 
             direction = yDist * up + zDist * forward + xDist * right;
         }
+        
+        [BurstCompile]
+        public Vector3 GetDirection(float x, float z, bool flipZAngles)
+        {
+            float x_ = x,
+                z_ = flipZAngles ? -z : z;
+
+            x_ = math.radians(x_);
+            z_ = math.radians(z_);
+            float tanx = math.tan(x_);
+            float tanz = math.tan(z_);
+
+            float yDist = math.sqrt(1 / (1 + math.pow(tanx, 2) + math.pow(tanz, 2)));
+            if (math.abs(x) > 90 || math.abs(z) > 90)
+            {
+                yDist = -yDist;
+            }
+
+            float xDist = tanz * yDist;
+            float zDist = tanx * yDist;
+
+            return new Vector3(xDist, yDist, zDist);
+        }
 
         public Vector3 GetDirection(Transform attachTransform, bool flipZAngles)
         {

--- a/Runtime/Interaction/HPUIInteractorRayAngle.cs
+++ b/Runtime/Interaction/HPUIInteractorRayAngle.cs
@@ -35,63 +35,17 @@ namespace ubco.ovilab.HPUI.Interaction
         {
             return dist < raySelectionThreshold;
         }
-
-        // /// <summary>
-        // /// Get a quaternion that would rotate x angles around its right axis and z angles around its forward axis.
-        // /// </summary>
-        // private static Quaternion GetRotation(float x, float z)
-        // {
-        //     float yDist = Mathf.Sqrt(1 / (1 + Mathf.Pow(Mathf.Tan(x * Mathf.Deg2Rad), 2) + Mathf.Pow(Mathf.Tan(z * Mathf.Deg2Rad), 2)));
-        //     if (Mathf.Abs(x) > 90 || Mathf.Abs(z) > 90)
-        //     {
-        //         yDist = -yDist;
-        //     }
-
-        //     float xDist = Mathf.Tan(x * Mathf.Deg2Rad) * yDist;
-        //     float zDist = Mathf.Tan(z * Mathf.Deg2Rad) * yDist;
-
-        //     Vector3 newUp = Vector3.up * yDist + Vector3.right * xDist + Vector3.forward * zDist;
-
-        //     // Don't care about the forward axis, as long the the up vector gets to the right postion
-        //     Vector3 newforward = Vector3.Cross(newUp, Quaternion.Euler(0, 0, 90) * newUp);
-        //     Vector3 newRight = Vector3.Cross(newforward, newUp);
-        //     Debug.Log($"{Vector3.Dot(newUp, Vector3.Cross(newRight, newforward))}");
-
-        //     return Quaternion.LookRotation(newUp, newforward);
-        //     // return Quaternion.LookRotation(Vector3.up, newUp);
-        // }
+        
         /// <summary>
-        /// The direction relatetive to the unity up, forward and right vectors.
+        /// The direction relative to the unity up, forward and right vectors.
         /// X is the angle from the up vector around the right vector.
         /// Z is the angle from the up vector around the forward vector.
         /// </summary>
-        [BurstCompile]
-        public static void GetDirection(float x, float z, in float3 right, in float3 forward, in float3 up, bool flipZAngles, out float3 direction)
-        {
-            float x_ = x,
-                  z_ = flipZAngles ? -z : z;
-
-            x_ = math.radians(x_);
-            z_ = math.radians(z_);
-            float tanx = math.tan(x_);
-            float tanz = math.tan(z_);
-
-            float yDist = math.sqrt(1 / (1 + math.pow(tanx, 2) + math.pow(tanz, 2)));
-            if (math.abs(x) > 90 || math.abs(z) > 90)
-            {
-                yDist = -yDist;
-            }
-
-            float xDist = tanz * yDist;
-            float zDist = tanx * yDist;
-
-            direction = yDist * up + zDist * forward + xDist * right;
-        }
         
         [BurstCompile]
-        public Vector3 GetDirection(float x, float z, bool flipZAngles)
+        public static float3 GetDirection(float x, float z, bool flipZAngles)
         {
-            float x_ = x,
+            float x_ = x, 
                 z_ = flipZAngles ? -z : z;
 
             x_ = math.radians(x_);
@@ -108,14 +62,10 @@ namespace ubco.ovilab.HPUI.Interaction
             float xDist = tanz * yDist;
             float zDist = tanx * yDist;
 
-            return new Vector3(xDist, yDist, zDist);
+            return new float3(xDist, yDist, zDist);
         }
 
-        public Vector3 GetDirection(Transform attachTransform, bool flipZAngles)
-        {
-            GetDirection(x, z, attachTransform.right, attachTransform.forward, attachTransform.up, flipZAngles, out float3 direction);
-            return direction;
-        }
+        
 
         #region Equality overrides
         public override bool Equals(object obj)

--- a/Runtime/Interaction/HPUIInteractorRayAngle.cs
+++ b/Runtime/Interaction/HPUIInteractorRayAngle.cs
@@ -7,45 +7,69 @@ namespace ubco.ovilab.HPUI.Interaction
 {
     // TODO docuement all of this
     [Serializable, BurstCompile]
-    public struct HPUIInteractorRayAngle
+    public class HPUIInteractorRayAngle
     {
         [SerializeField] private float x;
         [SerializeField] private float z;
         [SerializeField] private float raySelectionThreshold;
-
+        private Vector3 leftRayDirection;
+        private Vector3 rightRayDirection;
+        private bool isCached;
         public float X { get => x; }
         public float Z { get => z; }
         public float RaySelectionThreshold { get => raySelectionThreshold; set => raySelectionThreshold = value; }
-
         public HPUIInteractorRayAngle(float x, float z, float angleThreshold)
         {
             this.x = x;
             this.z = z;
             this.raySelectionThreshold = angleThreshold;
+            isCached = false;
+            GetDirection(x, z, false, out float3 _rightRay);
+            GetDirection(x, z, true, out float3 _leftRay);
+            this.rightRayDirection = _rightRay;
+            this.leftRayDirection = _leftRay;
         }
 
         public HPUIInteractorRayAngle(float x, float z)
         {
             this.x = x;
             this.z = z;
-            this.raySelectionThreshold = 1f;
+            isCached = false;
+            GetDirection(x, z, false, out float3 _rightRay);
+            GetDirection(x, z, true, out float3 _leftRay);
+            this.rightRayDirection = _rightRay;
+            this.leftRayDirection = _leftRay;
         }
 
         public bool WithinThreshold(float dist)
         {
             return dist < raySelectionThreshold;
         }
-        
+
+
+        public float3 GetDirection(bool isLeftHand)
+        {
+            if (!isCached)
+            {
+                isCached = true;
+                GetDirection(x, z, false, out float3 _rightRay);
+                GetDirection(x, z, true, out float3 _leftRay);
+                this.rightRayDirection = _rightRay;
+                this.leftRayDirection = _leftRay;
+            }
+
+            return isLeftHand ? leftRayDirection : rightRayDirection;
+        }
+
         /// <summary>
         /// The direction relative to the unity up, forward and right vectors.
         /// X is the angle from the up vector around the right vector.
         /// Z is the angle from the up vector around the forward vector.
         /// </summary>
-        
         [BurstCompile]
-        public static float3 GetDirection(float x, float z, bool flipZAngles)
+        public static void GetDirection(float x, float z, bool flipZAngles, out float3 direction)
         {
-            float x_ = x, 
+            float x_ = x,
                 z_ = flipZAngles ? -z : z;
 
             x_ = math.radians(x_);
@@ -61,11 +85,8 @@ namespace ubco.ovilab.HPUI.Interaction
 
             float xDist = tanz * yDist;
             float zDist = tanx * yDist;
-
-            return new float3(xDist, yDist, zDist);
+            direction = new float3(xDist, yDist, zDist);
         }
-
-        
 
         #region Equality overrides
         public override bool Equals(object obj)
@@ -90,4 +111,3 @@ namespace ubco.ovilab.HPUI.Interaction
         #endregion
     }
 }
- 

--- a/Runtime/Interaction/Logic/HPUIConeRayCastDetection.cs
+++ b/Runtime/Interaction/Logic/HPUIConeRayCastDetection.cs
@@ -49,7 +49,8 @@ namespace ubco.ovilab.HPUI.Interaction
         // When it's not set by DetectedInteractables, use default value
         protected List<HPUIInteractorRayAngle> activeFingerAngles = new();
         protected Dictionary<XRHandJointID, Vector3> jointLocations = new Dictionary<XRHandJointID, Vector3>();
-        private Dictionary<XRHandJointID, List<Vector3>> processedAngles = new();
+        private Dictionary<XRHandJointID, List<Vector3>> rightHandAngles = new();
+        private Dictionary<XRHandJointID, List<Vector3>> leftHandAngles = new();
         private bool isProcessedAnglesPopulated = false;
         protected List<XRHandJointID> trackedJoints = new List<XRHandJointID>()
         {
@@ -149,7 +150,8 @@ namespace ubco.ovilab.HPUI.Interaction
                 bool flipZAngles = interactor.handedness == InteractorHandedness.Left;
                 foreach (KeyValuePair<XRHandJointID, XRHandJointID> jointPairs in trackedJointsToSegment)
                 {
-                    List<Vector3> processedDirections = new();
+                    List<Vector3> processedDirectionsRight = new();
+                    List<Vector3> processedDirectionsLeft = new();
                     List<HPUIInteractorRayAngle> jointAngles = jointPairs.Key switch
                     {
                         XRHandJointID.IndexProximal      => ConeRayAngles.IndexProximalAngles,
@@ -169,10 +171,12 @@ namespace ubco.ovilab.HPUI.Interaction
                 
                     foreach (HPUIInteractorRayAngle angleData in jointAngles)
                     {
-                        processedDirections.Add(angleData.GetDirection(angleData.X, angleData.Z, flipZAngles));
+                        processedDirectionsRight.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
+                        processedDirectionsLeft.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
                     }
 
-                    processedAngles.Add(jointPairs.Key, processedDirections);
+                    rightHandAngles.Add(jointPairs.Key, processedDirectionsRight);
+                    leftHandAngles.Add(jointPairs.Key, processedDirectionsLeft);
                 }
 
                 isProcessedAnglesPopulated = true;
@@ -221,6 +225,7 @@ namespace ubco.ovilab.HPUI.Interaction
                         };
                 }
             }
+            Dictionary<XRHandJointID, List<Vector3>> processedAngles = interactor.handedness == InteractorHandedness.Right ? rightHandAngles : leftHandAngles;
             Process(interactor, interactionManager, activeFingerAngles, validTargets, out hoverEndPoint, processedAngles[closestJoint]);
         }
         

--- a/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
+++ b/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
@@ -17,8 +17,6 @@ namespace ubco.ovilab.HPUI.Interaction
         [SerializeField]
         [Tooltip("The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique")]
         private HPUIInteractorFullRangeAngles fullRangeRayAngles;
-        private List<Vector3> rightProcessedAngles = new();
-        private List<Vector3> leftProcessedAngles = new();
         private bool isProcessedAnglesPopulated = false;
         /// <summary>
         /// The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique
@@ -30,7 +28,6 @@ namespace ubco.ovilab.HPUI.Interaction
 
         public HPUIFullRangeRayCastDetectionLogic(float hoverRadius, HPUIInteractorFullRangeAngles fullRangeAngles)
         {
-            rightProcessedAngles = new();
             this.InteractionHoverRadius = hoverRadius;
             this.fullRangeRayAngles = fullRangeAngles;
         }
@@ -44,18 +41,8 @@ namespace ubco.ovilab.HPUI.Interaction
                 hoverEndPoint = interactor.GetAttachTransform(null).position;
                 return;
             }
-
-            if (!isProcessedAnglesPopulated)
-            {
-                foreach (HPUIInteractorRayAngle angleData in FullRangeRayAngles.angles)
-                {
-                    rightProcessedAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
-                    leftProcessedAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
-                }
-                isProcessedAnglesPopulated = true;
-            }
             
-            List<Vector3> processedAngles = interactor.handedness == InteractorHandedness.Right ? rightProcessedAngles : leftProcessedAngles;
+            List<Vector3> processedAngles = interactor.handedness == InteractorHandedness.Right ? FullRangeRayAngles.RightHandAngles : FullRangeRayAngles.LeftHandAngles;
             Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint, processedAngles);
         }
     }

--- a/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
+++ b/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
@@ -17,7 +17,8 @@ namespace ubco.ovilab.HPUI.Interaction
         [SerializeField]
         [Tooltip("The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique")]
         private HPUIInteractorFullRangeAngles fullRangeRayAngles;
-        private List<Vector3> processedAngles = new();
+        private List<Vector3> rightProcessedAngles = new();
+        private List<Vector3> leftProcessedAngles = new();
         private bool isProcessedAnglesPopulated = false;
         /// <summary>
         /// The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique
@@ -29,7 +30,7 @@ namespace ubco.ovilab.HPUI.Interaction
 
         public HPUIFullRangeRayCastDetectionLogic(float hoverRadius, HPUIInteractorFullRangeAngles fullRangeAngles)
         {
-            processedAngles = new();
+            rightProcessedAngles = new();
             this.InteractionHoverRadius = hoverRadius;
             this.fullRangeRayAngles = fullRangeAngles;
         }
@@ -46,15 +47,15 @@ namespace ubco.ovilab.HPUI.Interaction
 
             if (!isProcessedAnglesPopulated)
             {
-                bool flipZAngles = interactor.handedness == InteractorHandedness.Left;
                 foreach (HPUIInteractorRayAngle angleData in FullRangeRayAngles.angles)
                 {
-                    processedAngles.Add(angleData.GetDirection(angleData.X, angleData.Z, flipZAngles));
+                    rightProcessedAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, false));
+                    leftProcessedAngles.Add(HPUIInteractorRayAngle.GetDirection(angleData.X, angleData.Z, true));
                 }
-
                 isProcessedAnglesPopulated = true;
             }
-
+            
+            List<Vector3> processedAngles = interactor.handedness == InteractorHandedness.Right ? rightProcessedAngles : leftProcessedAngles;
             Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint, processedAngles);
         }
     }

--- a/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
+++ b/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
-using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
 namespace ubco.ovilab.HPUI.Interaction
 {
@@ -17,7 +16,7 @@ namespace ubco.ovilab.HPUI.Interaction
         [SerializeField]
         [Tooltip("The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique")]
         private HPUIInteractorFullRangeAngles fullRangeRayAngles;
-        private bool isProcessedAnglesPopulated = false;
+
         /// <summary>
         /// The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique
         /// </summary>
@@ -41,9 +40,8 @@ namespace ubco.ovilab.HPUI.Interaction
                 hoverEndPoint = interactor.GetAttachTransform(null).position;
                 return;
             }
-            
-            List<Vector3> processedAngles = interactor.handedness == InteractorHandedness.Right ? FullRangeRayAngles.RightHandAngles : FullRangeRayAngles.LeftHandAngles;
-            Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint, processedAngles);
+
+            Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint);
         }
     }
 }

--- a/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
+++ b/Runtime/Interaction/Logic/HPUIFullRangeRayCastDetectionLogic.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
+using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
 namespace ubco.ovilab.HPUI.Interaction
 {
@@ -16,7 +17,8 @@ namespace ubco.ovilab.HPUI.Interaction
         [SerializeField]
         [Tooltip("The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique")]
         private HPUIInteractorFullRangeAngles fullRangeRayAngles;
-
+        private List<Vector3> processedAngles = new();
+        private bool isProcessedAnglesPopulated = false;
         /// <summary>
         /// The HPUIInteractorFullRangeAngles asset to use for FullRange ray technique
         /// </summary>
@@ -27,6 +29,7 @@ namespace ubco.ovilab.HPUI.Interaction
 
         public HPUIFullRangeRayCastDetectionLogic(float hoverRadius, HPUIInteractorFullRangeAngles fullRangeAngles)
         {
+            processedAngles = new();
             this.InteractionHoverRadius = hoverRadius;
             this.fullRangeRayAngles = fullRangeAngles;
         }
@@ -41,7 +44,18 @@ namespace ubco.ovilab.HPUI.Interaction
                 return;
             }
 
-            Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint);
+            if (!isProcessedAnglesPopulated)
+            {
+                bool flipZAngles = interactor.handedness == InteractorHandedness.Left;
+                foreach (HPUIInteractorRayAngle angleData in FullRangeRayAngles.angles)
+                {
+                    processedAngles.Add(angleData.GetDirection(angleData.X, angleData.Z, flipZAngles));
+                }
+
+                isProcessedAnglesPopulated = true;
+            }
+
+            Process(interactor, interactionManager, FullRangeRayAngles.angles, validTargets, out hoverEndPoint, processedAngles);
         }
     }
 }

--- a/Runtime/Interaction/Logic/HPUIRayCastDetectionBaseLogic.cs
+++ b/Runtime/Interaction/Logic/HPUIRayCastDetectionBaseLogic.cs
@@ -89,7 +89,6 @@ namespace ubco.ovilab.HPUI.Interaction
             Transform attachTransform = interactor.GetAttachTransform(null);
             Vector3 interactionPoint = attachTransform.position;
             hoverEndPoint = interactionPoint;
-            bool flipZAngles = interactor.handedness == InteractorHandedness.Left;
             UnityEngine.Profiling.Profiler.BeginSample("Process angles");
             for (int i = 0; i < activeFingerAngles.Count; i++)
             {


### PR DESCRIPTION
Currently, Computing Direction for thousands of ray cast every frame is causing some noticeable slowdowns (even with burst) . I mostly made this change because my home laptop is struggling to keep up when I'm playing recorded sessions (< 60 fps). 

![image](https://github.com/user-attachments/assets/54cd84a9-2439-4b45-bc0c-26ae89482914)


I'm caching the directions individually in FullRange and ConeRay scripts. I couldnt think of a more elegant solution but it works.

![image](https://github.com/user-attachments/assets/3285d42c-0c96-4c82-9c62-01577aba966e)


Lemme know if you have a better way to go about this. This is hella jank 2 am code
