### PR TITLE
allowing applying uniform offsets to cone ray angles

### DIFF
--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -23,6 +23,8 @@ namespace ubco.ovilab.HPUI.Editor
         private Dictionary<XRHandJointID, List<float>> baselineThresholds = new Dictionary<XRHandJointID, List<float>>();
 
         private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Interaction.Components.ConeThresholdsEditor.DontAskForOverride";
+        private bool userSelection;
+        private string saveName;
 
         private bool advancedSettingsFoldout;
 
@@ -43,10 +45,10 @@ namespace ubco.ovilab.HPUI.Editor
         {
             base.OnInspectorGUI();
 
-            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
             advancedSettingsFoldout = EditorGUILayout.Foldout(advancedSettingsFoldout, "Advanced Settings", toggleOnLabelClick:true);
-            if(advancedSettingsFoldout)
+            if (advancedSettingsFoldout)
             {
                 EditorGUILayout.LabelField("Apply Ray Selection Threshold Offset", EditorStyles.boldLabel);
                 offsetValue = EditorGUILayout.FloatField("Offset", offsetValue);
@@ -58,95 +60,81 @@ namespace ubco.ovilab.HPUI.Editor
                 EditorGUI.EndDisabledGroup();
 
                 if (overwriteThisAsset) EditorGUILayout.HelpBox("You are about to overwrite this asset!", MessageType.Warning); // warning
-                if(overwriteThisAsset) GUI.backgroundColor = Color.red; // even more warning
-                if (GUILayout.Button(overwriteThisAsset ? "Overwrite this Asset and Apply Offset" : "Create Copy and Apply Offset"))
+                if (overwriteThisAsset) GUI.backgroundColor = Color.red; // more warning
+                if (GUILayout.Button(overwriteThisAsset
+                        ? "Overwrite this Asset and Apply Offset"
+                        : "Create Copy and Apply Offset"))
                 {
-                    Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
-
-                    if (applyToAll)
+                    if (overwriteThisAsset)
                     {
-                        if (overwriteThisAsset)
-                        {
-                            bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset",
-                                "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!",
-                                "Yes", "No", DialogOptOutDecisionType.ForThisSession,
-                                DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
-                            if (result)
-                            {
-                                foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t
-                                             .ActiveFingerAngles)
-                                {
-                                    ApplyOffsetToAsset(phalange, rayAngle);
-                                }
-
-                                EditorUtility.SetDirty(t);
-                                AssetDatabase.SaveAssets();
-                                AssetDatabase.Refresh();
-                            }
-                        }
-                        else
-                        {
-                            HPUIInteractorConeRayAngles newAsset = Instantiate(t);
-                            foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset
-                                         .ActiveFingerAngles)
-                            {
-                                ApplyOffsetToAsset(phalange, rayAngle);
-                            }
-
-                            string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
-                                $"{t.name}_copy_all_{offsetValue}", "asset",
-                                "Save location for the modified cone angle asset.");
-                            AssetDatabase.CreateAsset(newAsset, saveName);
-                            EditorUtility.SetDirty(newAsset);
-                            AssetDatabase.SaveAssets();
-                        }
+                        userSelection = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset",
+                            "Are you sure you want to overwrite this asset?" +
+                            "\nYou can undo or set offsets to 0 to regain original values." +
+                            "\nOnce you overwrite and close the editor the values will be permanently modified!",
+                            "Yes", "No", DialogOptOutDecisionType.ForThisSession,
+                            DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY); // https://www.youtube.com/watch?v=xrg-RgF5F8o Warning
+                        if (userSelection) ApplyModifications();
                     }
                     else
                     {
-                        if (t.ActiveFingerAngles.TryGetValue(selectedPhalange,
-                                out List<HPUIInteractorRayAngle> rayAngles))
-                        {
-                            if (overwriteThisAsset)
-                            {
-                                bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset",
-                                    "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!",
-                                    "Yes", "No", DialogOptOutDecisionType.ForThisSession,
-                                    DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
-                                if (result)
-                                {
-                                    ApplyOffsetToAsset(selectedPhalange, rayAngles);
-                                    EditorUtility.SetDirty(t);
-                                    AssetDatabase.SaveAssets();
-                                    AssetDatabase.Refresh();
-                                }
-                            }
-                            else
-                            {
-                                HPUIInteractorConeRayAngles newAsset = Instantiate(t);
-                                newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange,
-                                    out List<HPUIInteractorRayAngle> newRayAngles);
-                                Debug.Assert(newRayAngles != null,
-                                    "New asset copy doesn't have the same data as the old asset??");
-                                ApplyOffsetToAsset(selectedPhalange, newRayAngles);
-                                string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
-                                    $"{t.name}_copy_{selectedPhalange}_{offsetValue}", "asset",
-                                    "Save location for the modified cone angle asset.");
-                                AssetDatabase.CreateAsset(newAsset, saveName);
-                                EditorUtility.SetDirty(newAsset);
-                                AssetDatabase.SaveAssets();
-                            }
-                        }
-                        else
-                        {
-                            Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
-                        }
+                        saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
+                            $"{t.name}_copy_all_{offsetValue}", "asset",
+                            "Save location for the modified cone angle asset.");
+                        if (!string.IsNullOrWhiteSpace(saveName)) ApplyModifications();
                     }
                 }
             }
+        }
 
+        private void ApplyModifications()
+        {
+            if(overwriteThisAsset)
+            {
+                Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
+                if (applyToAll)
+                {
+                    foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t.ActiveFingerAngles)
+                    {
+                        ApplyOffsetToAsset(phalange, rayAngle);
+                    }
 
-
-
+                }
+                else // apply to selected phalange
+                {
+                    if (t.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> rayAngles))
+                    {
+                        ApplyOffsetToAsset(selectedPhalange, rayAngles);
+                    }
+                    else
+                    {
+                        Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
+                    }
+                }
+                EditorUtility.SetDirty(t);
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+            }
+            else
+            {
+                Debug.Assert(!string.IsNullOrWhiteSpace(saveName), "How is apply mods true then?");
+                HPUIInteractorConeRayAngles newAsset = Instantiate(t);
+                if (applyToAll)
+                {
+                    foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset.ActiveFingerAngles)
+                    {
+                        ApplyOffsetToAsset(phalange, rayAngle);
+                    }
+                }
+                else
+                {
+                    newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> newRayAngles);
+                    Debug.Assert(newRayAngles != null, "New asset copy doesn't have the same data as the old asset??");
+                    ApplyOffsetToAsset(selectedPhalange, newRayAngles);
+                }
+                AssetDatabase.CreateAsset(newAsset, saveName);
+                EditorUtility.SetDirty(newAsset);
+                AssetDatabase.SaveAssets();
+            }
         }
 
         /// <summary>

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -22,11 +22,13 @@ namespace ubco.ovilab.HPUI.Editor
         // storing all baseline thresholds
         private Dictionary<XRHandJointID, List<float>> baselineThresholds = new Dictionary<XRHandJointID, List<float>>();
 
-        private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Interaction.Components.ConeThresholdsEditor.DontAskForOverride";
+        private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Interaction.ConeThresholdsEditor.DontAskForOverride";
         private bool userSelection;
-        private string saveName;
+        private string newAssetFileSaveName;
 
         private bool advancedSettingsFoldout;
+
+        private const string OFFSET_TOOLTIP = "The uniform offset to apply to the ray thresholds for a given phalange or all phalanges. Note that it always applies it from the base values, which are derived upon the first time the asset is selected in this Unity session. So setting it to 2 and then 1 won't increment it by 3, the second operation will only increment it by 1 from the base amount. Consequently, setting it to 0 will reset it to whatever the original values were.";
 
         protected void OnEnable()
         {
@@ -47,23 +49,24 @@ namespace ubco.ovilab.HPUI.Editor
 
             EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
-            advancedSettingsFoldout = EditorGUILayout.Foldout(advancedSettingsFoldout, "Advanced Settings", toggleOnLabelClick:true);
+            advancedSettingsFoldout = EditorGUILayout.Foldout(advancedSettingsFoldout, "Advanced Operations", toggleOnLabelClick:true);
             if (advancedSettingsFoldout)
             {
                 EditorGUILayout.LabelField("Apply Ray Selection Threshold Offset", EditorStyles.boldLabel);
-                offsetValue = EditorGUILayout.FloatField("Offset", offsetValue);
-                applyToAll = EditorGUILayout.Toggle("Apply to All", applyToAll);
+                offsetValue = EditorGUILayout.FloatField(new GUIContent("Offset", OFFSET_TOOLTIP), offsetValue);
+                applyToAll = EditorGUILayout.Toggle(new GUIContent("Apply to All", "apply offset to all phalanges at once"), applyToAll);
                 overwriteThisAsset = EditorGUILayout.Toggle("Overwrite This Asset", overwriteThisAsset);
 
                 EditorGUI.BeginDisabledGroup(applyToAll);
                 selectedPhalange = (XRHandJointID)EditorGUILayout.EnumPopup("Phalange", selectedPhalange);
                 EditorGUI.EndDisabledGroup();
 
-                if (overwriteThisAsset) EditorGUILayout.HelpBox("You are about to overwrite this asset!", MessageType.Warning); // warning
-                if (overwriteThisAsset) GUI.backgroundColor = Color.red; // more warning
-                if (GUILayout.Button(overwriteThisAsset
-                        ? "Overwrite this Asset and Apply Offset"
-                        : "Create Copy and Apply Offset"))
+                if (overwriteThisAsset)
+                {
+                    EditorGUILayout.HelpBox("You are about to overwrite this asset!", MessageType.Warning); // warning
+                    GUI.backgroundColor = Color.red; // more warning
+                }
+                if (GUILayout.Button(overwriteThisAsset ? "Overwrite this Asset and Apply Offset" : "Create Copy and Apply Offset"))
                 {
                     if (overwriteThisAsset)
                     {
@@ -73,14 +76,20 @@ namespace ubco.ovilab.HPUI.Editor
                             "\nOnce you overwrite and close the editor the values will be permanently modified!",
                             "Yes", "No", DialogOptOutDecisionType.ForThisSession,
                             DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY); // https://www.youtube.com/watch?v=xrg-RgF5F8o Warning
-                        if (userSelection) ApplyModifications();
+                        if (userSelection)
+                        {
+                            ApplyModifications();
+                        }
                     }
                     else
                     {
-                        saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
+                        newAssetFileSaveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
                             $"{t.name}_copy_all_{offsetValue}", "asset",
                             "Save location for the modified cone angle asset.");
-                        if (!string.IsNullOrWhiteSpace(saveName)) ApplyModifications();
+                        if (!string.IsNullOrWhiteSpace(newAssetFileSaveName))
+                        {
+                            ApplyModifications(newAssetFileSaveName);
+                        }
                     }
                 }
             }
@@ -88,53 +97,52 @@ namespace ubco.ovilab.HPUI.Editor
 
         private void ApplyModifications()
         {
-            if(overwriteThisAsset)
+            Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
+            if (applyToAll)
             {
-                Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
-                if (applyToAll)
+                foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t.ActiveFingerAngles)
                 {
-                    foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t.ActiveFingerAngles)
-                    {
-                        ApplyOffsetToAsset(phalange, rayAngle);
-                    }
+                    ApplyOffsetToAsset(phalange, rayAngle);
+                }
 
-                }
-                else // apply to selected phalange
-                {
-                    if (t.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> rayAngles))
-                    {
-                        ApplyOffsetToAsset(selectedPhalange, rayAngles);
-                    }
-                    else
-                    {
-                        Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
-                    }
-                }
-                EditorUtility.SetDirty(t);
-                AssetDatabase.SaveAssets();
-                AssetDatabase.Refresh();
             }
-            else
+            else // apply to selected phalange
             {
-                Debug.Assert(!string.IsNullOrWhiteSpace(saveName), "How is apply mods true then?");
-                HPUIInteractorConeRayAngles newAsset = Instantiate(t);
-                if (applyToAll)
+                if (t.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> rayAngles))
                 {
-                    foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset.ActiveFingerAngles)
-                    {
-                        ApplyOffsetToAsset(phalange, rayAngle);
-                    }
+                    ApplyOffsetToAsset(selectedPhalange, rayAngles);
                 }
                 else
                 {
-                    newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> newRayAngles);
-                    Debug.Assert(newRayAngles != null, "New asset copy doesn't have the same data as the old asset??");
-                    ApplyOffsetToAsset(selectedPhalange, newRayAngles);
+                    throw new Exception("Selected phalange not found in ActiveFingerAngles.");
                 }
-                AssetDatabase.CreateAsset(newAsset, saveName);
-                EditorUtility.SetDirty(newAsset);
-                AssetDatabase.SaveAssets();
             }
+            EditorUtility.SetDirty(t);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+
+        private void ApplyModifications(string newAssetSavePath)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(newAssetSavePath), "Invalid Save Path!");
+            HPUIInteractorConeRayAngles newAsset = Instantiate(t);
+            if (applyToAll)
+            {
+                foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset.ActiveFingerAngles)
+                {
+                    ApplyOffsetToAsset(phalange, rayAngle);
+                }
+            }
+            else // apply to selected phalange
+            {
+                newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> newRayAngles);
+                Debug.Assert(newRayAngles != null, "New asset copy doesn't have the same data as the old asset??");
+                ApplyOffsetToAsset(selectedPhalange, newRayAngles);
+            }
+            AssetDatabase.CreateAsset(newAsset, newAssetSavePath);
+            EditorUtility.SetDirty(newAsset);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
         }
 
         /// <summary>

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -22,7 +22,7 @@ namespace ubco.ovilab.HPUI.Editor
         // storing all baseline thresholds
         private Dictionary<XRHandJointID, List<float>> baselineThresholds = new Dictionary<XRHandJointID, List<float>>();
 
-        private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Components.ConeThresholdsEditor.DontAskForOverride";
+        private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Interaction.Components.ConeThresholdsEditor.DontAskForOverride";
 
         protected void OnEnable()
         {

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+using ubco.ovilab.HPUI.Interaction;
+using UnityEngine.XR.Hands;
+
+namespace ubco.ovilab.HPUI.Editor
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(HPUIInteractorConeRayAngles), true)]
+    public class HPUIInteractorConeAnglesEditor: UnityEditor.Editor
+    {
+        private HPUIInteractorConeRayAngles t;
+
+        private float offsetValue;
+        private bool applyToAll;
+        private XRHandJointID selectedPhalange = XRHandJointID.IndexDistal;
+
+        // storing all baseline thresholds for first ray per phalange
+        // assuming that offsets are applied uniformly per phalange
+        private Dictionary<XRHandJointID, float> baselineThresholds = new Dictionary<XRHandJointID, float>();
+        // storing previous applied offset
+        private Dictionary<XRHandJointID, float> cachedOffsets = new Dictionary<XRHandJointID, float>();
+
+        protected void OnEnable()
+        {
+            t = target as HPUIInteractorConeRayAngles;
+            foreach (var kvp in t.ActiveFingerAngles)
+            {
+                XRHandJointID phalange = kvp.Key;
+                List<HPUIInteractorRayAngle> rayAngles = kvp.Value;
+                if (!baselineThresholds.ContainsKey(phalange))
+                {
+                    try
+                    {
+                        baselineThresholds[phalange] = rayAngles.Select(ray => ray.RaySelectionThreshold).ToList()[0];
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // this is little proximal, that needs to be fixed at some point in time
+                    }
+                }
+                if (cachedOffsets.ContainsKey(phalange)) continue;
+                float initialOffset = rayAngles.Count > 0 ? rayAngles[0].RaySelectionThreshold - baselineThresholds[phalange] : 0f;
+                cachedOffsets[phalange] = initialOffset;
+            }
+            Undo.undoRedoPerformed += OnUndoRedoEvent;
+        }
+
+        protected void OnDisable()
+        {
+            Undo.undoRedoPerformed -= OnUndoRedoEvent;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.LabelField("Apply Ray Selection Threshold Offset", EditorStyles.boldLabel);
+            offsetValue = EditorGUILayout.FloatField("Offset", offsetValue);
+            applyToAll = EditorGUILayout.Toggle("Apply to All", applyToAll);
+
+            EditorGUI.BeginDisabledGroup(applyToAll);
+            selectedPhalange = (XRHandJointID)EditorGUILayout.EnumPopup("Phalange", selectedPhalange);
+            EditorGUI.EndDisabledGroup();
+
+            if (GUILayout.Button("Apply Offset"))
+            {
+                Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
+
+                if (applyToAll)
+                {
+                    foreach (KeyValuePair<XRHandJointID, List<HPUIInteractorRayAngle>> kvp in t.ActiveFingerAngles)
+                    {
+                        ApplyOffsetToList(kvp.Key, kvp.Value);
+                    }
+                }
+                else
+                {
+                    if (t.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> list))
+                    {
+                        ApplyOffsetToList(selectedPhalange, list);
+                    }
+                    else
+                    {
+                        Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
+                    }
+                }
+                EditorUtility.SetDirty(t);
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+            }
+
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+
+        /// <summary>
+        /// applies offsets based on original threshold value
+        /// </summary>
+        private void ApplyOffsetToList(XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngles)
+        {
+            float previousOffset = cachedOffsets.GetValueOrDefault(phalange, 0f);
+
+            foreach (HPUIInteractorRayAngle rayAngle in rayAngles)
+            {
+                rayAngle.RaySelectionThreshold = rayAngle.RaySelectionThreshold - previousOffset + offsetValue;
+            }
+
+            cachedOffsets[phalange] = offsetValue;
+        }
+
+        /// <summary>
+        /// Called on Undo/Redo. For each phalange, recompute the post undo/redo applied offset from the current thresholds.
+        /// </summary>
+        private void OnUndoRedoEvent()
+        {
+            foreach (var kvp in t.ActiveFingerAngles)
+            {
+                XRHandJointID phalange = kvp.Key;
+                var rayAngles = kvp.Value;
+                if (rayAngles.Count > 0 && baselineThresholds.TryGetValue(phalange, out float threshold))
+                {
+                    // Assuming all ray angles were modified uniformly, update the cached offset based on the first element.
+                    float newOffset = rayAngles[0].RaySelectionThreshold - threshold;
+                    cachedOffsets[phalange] = newOffset;
+                }
+            }
+            Repaint();
+
+        }
+    }
+}

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -24,6 +24,8 @@ namespace ubco.ovilab.HPUI.Editor
 
         private const string DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY = "ubco.ovilab.HPUI.Interaction.Components.ConeThresholdsEditor.DontAskForOverride";
 
+        private bool advancedSettingsFoldout;
+
         protected void OnEnable()
         {
             t = target as HPUIInteractorConeRayAngles;
@@ -39,58 +41,44 @@ namespace ubco.ovilab.HPUI.Editor
 
         public override void OnInspectorGUI()
         {
-            EditorGUILayout.LabelField("Apply Ray Selection Threshold Offset", EditorStyles.boldLabel);
-            offsetValue = EditorGUILayout.FloatField("Offset", offsetValue);
-            applyToAll = EditorGUILayout.Toggle("Apply to All", applyToAll);
-            overwriteThisAsset = EditorGUILayout.Toggle("Overwrite This Asset", overwriteThisAsset);
+            base.OnInspectorGUI();
 
-            EditorGUI.BeginDisabledGroup(applyToAll);
-            selectedPhalange = (XRHandJointID)EditorGUILayout.EnumPopup("Phalange", selectedPhalange);
-            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.Space();
 
-            if (GUILayout.Button(overwriteThisAsset ? "Overwrite this Asset and Apply Offset" : "Create Copy and Apply Offset"))
+            advancedSettingsFoldout = EditorGUILayout.Foldout(advancedSettingsFoldout, "Advanced Settings", toggleOnLabelClick:true);
+            if(advancedSettingsFoldout)
             {
-                Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
+                EditorGUILayout.LabelField("Apply Ray Selection Threshold Offset", EditorStyles.boldLabel);
+                offsetValue = EditorGUILayout.FloatField("Offset", offsetValue);
+                applyToAll = EditorGUILayout.Toggle("Apply to All", applyToAll);
+                overwriteThisAsset = EditorGUILayout.Toggle("Overwrite This Asset", overwriteThisAsset);
 
-                if (applyToAll)
+                EditorGUI.BeginDisabledGroup(applyToAll);
+                selectedPhalange = (XRHandJointID)EditorGUILayout.EnumPopup("Phalange", selectedPhalange);
+                EditorGUI.EndDisabledGroup();
+
+                if (overwriteThisAsset) EditorGUILayout.HelpBox("You are about to overwrite this asset!", MessageType.Warning); // warning
+                if(overwriteThisAsset) GUI.backgroundColor = Color.red; // even more warning
+                if (GUILayout.Button(overwriteThisAsset ? "Overwrite this Asset and Apply Offset" : "Create Copy and Apply Offset"))
                 {
-                    if(overwriteThisAsset)
-                    {
-                        bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset", "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!", "Yes", "No", DialogOptOutDecisionType.ForThisSession, DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
-                        if(result)
-                        {
-                            foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t.ActiveFingerAngles)
-                            {
-                                ApplyOffsetToAsset(phalange, rayAngle);
-                            }
-                            EditorUtility.SetDirty(t);
-                            AssetDatabase.SaveAssets();
-                            AssetDatabase.Refresh();
-                        }
-                    }
-                    else
-                    {
-                        HPUIInteractorConeRayAngles newAsset = Instantiate(t);
-                        foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset.ActiveFingerAngles)
-                        {
-                            ApplyOffsetToAsset(phalange, rayAngle);
-                        }
-                        string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset", $"{t.name}_copy_all_{offsetValue}", "asset", "Save location for the modified cone angle asset.");
-                        AssetDatabase.CreateAsset(newAsset, saveName);
-                        EditorUtility.SetDirty(newAsset);
-                        AssetDatabase.SaveAssets();
-                    }
-                }
-                else
-                {
-                    if (t.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> rayAngles))
+                    Undo.RecordObject(t, "Apply RaySelectionThreshold Offset");
+
+                    if (applyToAll)
                     {
                         if (overwriteThisAsset)
                         {
-                            bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset", "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!", "Yes", "No", DialogOptOutDecisionType.ForThisSession, DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
+                            bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset",
+                                "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!",
+                                "Yes", "No", DialogOptOutDecisionType.ForThisSession,
+                                DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
                             if (result)
                             {
-                                ApplyOffsetToAsset(selectedPhalange, rayAngles);
+                                foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in t
+                                             .ActiveFingerAngles)
+                                {
+                                    ApplyOffsetToAsset(phalange, rayAngle);
+                                }
+
                                 EditorUtility.SetDirty(t);
                                 AssetDatabase.SaveAssets();
                                 AssetDatabase.Refresh();
@@ -99,10 +87,15 @@ namespace ubco.ovilab.HPUI.Editor
                         else
                         {
                             HPUIInteractorConeRayAngles newAsset = Instantiate(t);
-                            newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange, out List<HPUIInteractorRayAngle> newRayAngles);
-                            Debug.Assert(newRayAngles!=null, "New asset copy doesn't have the same data as the old asset??");
-                            ApplyOffsetToAsset(selectedPhalange, newRayAngles);
-                            string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset", $"{t.name}_copy_{selectedPhalange}_{offsetValue}", "asset", "Save location for the modified cone angle asset.");
+                            foreach ((XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngle) in newAsset
+                                         .ActiveFingerAngles)
+                            {
+                                ApplyOffsetToAsset(phalange, rayAngle);
+                            }
+
+                            string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
+                                $"{t.name}_copy_all_{offsetValue}", "asset",
+                                "Save location for the modified cone angle asset.");
                             AssetDatabase.CreateAsset(newAsset, saveName);
                             EditorUtility.SetDirty(newAsset);
                             AssetDatabase.SaveAssets();
@@ -110,14 +103,50 @@ namespace ubco.ovilab.HPUI.Editor
                     }
                     else
                     {
-                        Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
+                        if (t.ActiveFingerAngles.TryGetValue(selectedPhalange,
+                                out List<HPUIInteractorRayAngle> rayAngles))
+                        {
+                            if (overwriteThisAsset)
+                            {
+                                bool result = EditorUtility.DisplayDialog("Overwrite Cone Ray Angles Asset",
+                                    "Are you sure you want to overwrite this asset?\nYou can undo or set offsets to 0 to regain original values.\nOnce you overwrite and close the editor the values will be permanently modified!",
+                                    "Yes", "No", DialogOptOutDecisionType.ForThisSession,
+                                    DONT_ASK_FOR_OVERRIDE_EDITOR_PREF_KEY);
+                                if (result)
+                                {
+                                    ApplyOffsetToAsset(selectedPhalange, rayAngles);
+                                    EditorUtility.SetDirty(t);
+                                    AssetDatabase.SaveAssets();
+                                    AssetDatabase.Refresh();
+                                }
+                            }
+                            else
+                            {
+                                HPUIInteractorConeRayAngles newAsset = Instantiate(t);
+                                newAsset.ActiveFingerAngles.TryGetValue(selectedPhalange,
+                                    out List<HPUIInteractorRayAngle> newRayAngles);
+                                Debug.Assert(newRayAngles != null,
+                                    "New asset copy doesn't have the same data as the old asset??");
+                                ApplyOffsetToAsset(selectedPhalange, newRayAngles);
+                                string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset",
+                                    $"{t.name}_copy_{selectedPhalange}_{offsetValue}", "asset",
+                                    "Save location for the modified cone angle asset.");
+                                AssetDatabase.CreateAsset(newAsset, saveName);
+                                EditorUtility.SetDirty(newAsset);
+                                AssetDatabase.SaveAssets();
+                            }
+                        }
+                        else
+                        {
+                            Debug.LogWarning("Selected phalange not found in ActiveFingerAngles.");
+                        }
                     }
                 }
             }
 
-            EditorGUILayout.Space();
 
-            base.OnInspectorGUI();
+
+
         }
 
         /// <summary>

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs
@@ -150,13 +150,10 @@ namespace ubco.ovilab.HPUI.Editor
         /// </summary>
         private void ApplyOffsetToAsset(XRHandJointID phalange, List<HPUIInteractorRayAngle> rayAngles)
         {
-            List<float> baselineThresholdsForPhalange = baselineThresholds.GetValueOrDefault(phalange, null);
-
+            List<float> baselineThresholdsForPhalange = baselineThresholds[phalange];
             for (int i = 0; i < rayAngles.Count; i++)
             {
-                HPUIInteractorRayAngle rayAngle = rayAngles[i];
-                float baseThreshold = baselineThresholdsForPhalange[i];
-                rayAngle.RaySelectionThreshold = baseThreshold + offsetValue;
+                rayAngles[i].RaySelectionThreshold = baselineThresholdsForPhalange[i] + offsetValue;
             }
         }
     }

--- a/Editor/HPUIInteractorConeRayAnglesEditor.cs.meta
+++ b/Editor/HPUIInteractorConeRayAnglesEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8c574c0be407404e9a64aea8310426ed
+timeCreated: 1739718722


### PR DESCRIPTION
### Overview

Allows modifying the asset's ray distance thresholds uniformly per phalange. Useful for making quick modifications to scale up or down the interaction selection radius. Optionally also allows applying the offset over all phalanges at once. Applies it with respect to the base value. Also supports undoing and redoing (and handles the previous computed offsets properly).

![image](https://github.com/user-attachments/assets/402715bf-683c-40be-b35d-7da460a2cf57)