### PR TITLE
formatting rules for csharpier

### DIFF
--- a/.csharpierrc
+++ b/.csharpierrc
@@ -1,0 +1,6 @@
+{
+    "printWidth": 600,
+    "useTabs": false,
+    "indentSize": 4,
+    "endOfLine": "auto"
+}


### PR DESCRIPTION
preserves most of the repo, except for spacing issues between reserved keyword and function names and the following open brakets. Ideally we should all be using this moving forward to avoid commit diffs containing formatting changes?