### PR TITLE
Generalize cone ray estimation procedure

### DIFF
--- a/Editor/ConeRayAnglesCalibrationRoutineEditor.cs
+++ b/Editor/ConeRayAnglesCalibrationRoutineEditor.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+using UnityEditor;
+using ubco.ovilab.HPUI.Interaction;
+using ubco.ovilab.HPUI.Components;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using UnityEngine.XR.Hands;
+
+namespace ubco.ovilab.HPUI.Editor
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(ConeRayAnglesCalibrationRoutine), true)]
+    public class ConeRayAnglesCalibrationRoutineEditor : UnityEditor.Editor
+    {
+        private enum State { Wait, Started, Processing, Processed }
+        private class StateInformation
+        {
+            public State state = State.Wait;
+            public HPUIInteractorConeRayAngles generatedAsset, savedAsset;
+            public StateInformation(State state = State.Wait, HPUIInteractorConeRayAngles generatedAsset = null, HPUIInteractorConeRayAngles savedAsset = null)
+            {
+                this.state = state;
+                this.generatedAsset = generatedAsset;
+                this.savedAsset = savedAsset;
+            }
+        }
+
+        private SerializedObject generatedConeRayAnglesObj;
+        private string collectDataButtonString = "Start Data Collection";
+        private bool isCollectingData = false, showXRHandtrackingEventsMissingMessage;
+        private ConeRayAnglesCalibrationRoutine t;
+        private bool hasSomeDataBeenCollected = false;
+        private StateInformation stateInfo;
+
+        protected void OnEnable()
+        {
+            t = target as ConeRayAnglesCalibrationRoutine;
+            stateInfo = new StateInformation();
+        }
+
+        protected void CheckIfShowXRHandtrackingEventsMissingMessage()
+        {
+            showXRHandtrackingEventsMissingMessage = t.SetDetectionLogicOnEstimation && t.XRHandTrackingEventsForConeDetection == null && t.Interactor.GetComponent<XRHandTrackingEvents>() == null;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+            CheckIfShowXRHandtrackingEventsMissingMessage();
+
+            if (showXRHandtrackingEventsMissingMessage)
+            {
+                EditorGUILayout.HelpBox("While SetDetectionLogicOnEstimation is set, XRHandTrackingEventsForConeDetection is null and Interactor doesn't have an XRHandTrackingEvents component.", MessageType.Error);
+            }
+
+            EditorGUILayout.Space();
+            GUI.enabled = !showXRHandtrackingEventsMissingMessage && Application.isPlaying;
+
+            if (GUILayout.Button(collectDataButtonString))
+            {
+                if (!isCollectingData) // start data collection
+                {
+                    t.StartDataCollectionForPhalange();
+                    collectDataButtonString = "Stop Data Collection";
+                    stateInfo.state = State.Started;
+                }
+                else // stop data collection
+                {
+                    t.EndDataCollectionForPhalange();
+                    collectDataButtonString = "Start Data Collection";
+
+                    // cycling strategy to automatically move to the next phalange.
+                    // saves some headache when running a calibration protocol.
+                    int phalangeCount = Enum.GetNames(typeof(HPUIInteractorConeRayAngleSegment)).Length;
+                    int currentPhalangeIndex = Array.IndexOf(Enum.GetValues(typeof(HPUIInteractorConeRayAngleSegment)), t.TargetSegment);
+                    if (currentPhalangeIndex < phalangeCount - 1) t.TargetSegment = (HPUIInteractorConeRayAngleSegment)currentPhalangeIndex + 1;
+                    else t.TargetSegment = (HPUIInteractorConeRayAngleSegment)0;
+
+                    hasSomeDataBeenCollected = true;
+                }
+                isCollectingData = !isCollectingData;
+            }
+
+            EditorGUILayout.Space();
+            GUI.enabled = hasSomeDataBeenCollected;
+            if (GUILayout.Button("Process Data"))
+            {
+                t.FinishAndEstimate((angles) =>
+                {
+
+                    stateInfo.state = State.Processing;
+                    t.FinishAndEstimate((angles) =>
+                    {
+                        stateInfo.state = State.Processed;
+                        this.stateInfo.generatedAsset = angles;
+                    });
+                });
+            }
+
+            EditorGUILayout.Space();
+            if (stateInfo.state == State.Processing)
+            {
+                EditorGUILayout.LabelField("Processing new cone ray angles...");
+            }
+
+            if (stateInfo.state == State.Processed)
+            {
+                EditorGUILayout.Space();
+                if (GUILayout.Button("Save Data"))
+                {
+
+                    if (stateInfo.generatedAsset != null)
+                    {
+                        generatedConeRayAnglesObj = new SerializedObject(stateInfo.generatedAsset);
+                        string saveName = EditorUtility.SaveFilePanelInProject("Save new cone angles asset", "NewHPUIInteractorConeRayAngles.asset", "asset", "Save location for the generated cone angle asset.");
+                        AssetDatabase.CreateAsset(stateInfo.generatedAsset, saveName);
+                        AssetDatabase.SaveAssets();
+                        stateInfo.savedAsset = stateInfo.generatedAsset;
+                    }
+                }
+            }
+
+            serializedObject.ApplyModifiedProperties();
+
+        }
+    }
+}

--- a/Editor/ConeRayAnglesCalibrationRoutineEditor.cs.meta
+++ b/Editor/ConeRayAnglesCalibrationRoutineEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09e42c373c99a2f4abab9368e77feb4a

--- a/Runtime/Components/ConeRayAnglesCalibrationRoutine.cs
+++ b/Runtime/Components/ConeRayAnglesCalibrationRoutine.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using UnityEngine.XR.Hands;
+using ubco.ovilab.HPUI.Interaction;
+using UnityEngine.Assertions;
+
+namespace ubco.ovilab.HPUI.Components
+{
+    public class ConeRayAnglesCalibrationRoutine : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Corresponding Interactor")]
+        private HPUIInteractor interactor;
+
+        /// <summary>
+        /// The interactor used for the estimation.
+        /// </summary>
+        public HPUIInteractor Interactor { get => interactor; set => interactor = value; }
+
+        [SerializeField]
+        [Tooltip("Phalange that the interactor is currently being calibrated for")]
+        private HPUIInteractorConeRayAngleSegment targetSegment;
+
+        /// <summary>
+        /// Phalange that the interactor is currently being calibrated for
+        /// </summary>
+        public HPUIInteractorConeRayAngleSegment TargetSegment { get => targetSegment; set => targetSegment = value; }
+
+        [SerializeField]
+        [Tooltip("If true, will set the detection logic of interactor to HPUIConeRayCastDetectionLogic with generated asset.")]
+        private bool setDetectionLogicOnEstimation = false;
+
+        /// <summary>
+        /// If true, will set the detection logic of interactor to HPUIConeRayCastDetectionLogic with generated asset.
+        /// </summary>
+        public bool SetDetectionLogicOnEstimation { get => setDetectionLogicOnEstimation; set => setDetectionLogicOnEstimation = value; }
+
+        [SerializeField]
+        [Tooltip("(optional) The hand tracking event to use with HPUIConeRayCastDetectionLogic if SetDetectionLogicOnEstimation is true." +
+                 "If this is not set, then will look for XRHandTrackingEvents in the Interactor.")]
+        private XRHandTrackingEvents xrHandTrackingEventsForConeDetection;
+
+        /// <summary>
+        /// The hand tracking event to use with HPUIConeRayCastDetectionLogic if SetDetectionLogicOnEstimation is true.
+        /// If this is not set, then will look for XRHandTrackingEvents in the Interactor.
+        /// </summary>
+        public XRHandTrackingEvents XRHandTrackingEventsForConeDetection { get => xrHandTrackingEventsForConeDetection; set => xrHandTrackingEventsForConeDetection = value; }
+
+        private ConeRayAnglesCalibrator calibrator;
+        private HPUIFullRangeRayCastDetectionLogic fullrangeRaycastDetectionLogicReference;
+        private bool initComplete = false;
+
+        private void BeginDataCollectionProcedure()
+        {
+            if (!Application.isPlaying) return;
+            if (SetDetectionLogicOnEstimation)
+            {
+                Assert.IsTrue(XRHandTrackingEventsForConeDetection != null || Interactor.GetComponent<XRHandTrackingEvents>() != null,
+                              "XRHandTrackingEventsForConeDetection is null and Interactor doesn't have an XRHandTrackingEvents component.");
+            }
+
+            if (!(Interactor.DetectionLogic is HPUIFullRangeRayCastDetectionLogic))
+            {
+                if (fullrangeRaycastDetectionLogicReference == null)
+                {
+                    throw new ArgumentException("Expected interactor to be configured with HPUIInteractorFullRangeAngles.");
+                }
+
+                Interactor.DetectionLogic = fullrangeRaycastDetectionLogicReference as IHPUIDetectionLogic;
+            }
+            else
+            {
+                fullrangeRaycastDetectionLogicReference = Interactor.DetectionLogic as HPUIFullRangeRayCastDetectionLogic;
+            }
+
+            calibrator = new ConeRayAnglesCalibrator(interactor);
+            initComplete = true;
+        }
+
+        public void StartDataCollectionForPhalange()
+        {
+            if (!initComplete) BeginDataCollectionProcedure();
+            calibrator.IsCalibrationActive = true;
+        }
+
+        public void EndDataCollectionForPhalange()
+        {
+            calibrator.EndCalibrationForSegment(TargetSegment);
+            calibrator.IsCalibrationActive = false;
+        }
+
+        public void FinishAndEstimate(Action<HPUIInteractorConeRayAngles> callback)
+        {
+            Assert.IsTrue(!calibrator.IsCalibrationActive, "Calibration is currently active, end that first!");
+            calibrator.EstimateConeRayAngles((angles) =>
+            {
+                callback.Invoke(angles);
+                if (SetDetectionLogicOnEstimation)
+                {
+                    Interactor.DetectionLogic = new HPUIConeRayCastDetectionLogic(
+                        Interactor.DetectionLogic.InteractionHoverRadius,
+                        angles,
+                        XRHandTrackingEventsForConeDetection != null ? XRHandTrackingEventsForConeDetection : Interactor.GetComponent<XRHandTrackingEvents>());
+                }
+            });
+        }
+    }
+}

--- a/Runtime/Components/ConeRayAnglesCalibrationRoutine.cs.meta
+++ b/Runtime/Components/ConeRayAnglesCalibrationRoutine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 68149527c63a33b49b31bfb4fa62115c

--- a/Runtime/Components/ConeRayAnglesCalibrator.cs
+++ b/Runtime/Components/ConeRayAnglesCalibrator.cs
@@ -1,0 +1,258 @@
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using UnityEngine.Assertions;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections;
+using ubco.ovilab.HPUI.Interaction;
+
+namespace ubco.ovilab.HPUI.Components
+{
+    /// <summary>
+    /// Calibrates a new set of cone ray cone ray angles
+    /// to be used for <see cref="HPUIInteractor.DetectionLogic"/>
+    /// Works similar to <see cref="ConeRayAnglesEstimator"/> except it
+    /// uses multiple frames to estimate an average length
+    /// of interaction per ray. Makes use of <see cref="HPUIInteractorConeRayAngleSegment"/>
+    /// from <see cref="ConeRayAnglesEstimator"/> for the list of phalanges.
+    /// </summary>
+    public class ConeRayAnglesCalibrator
+    {
+        private bool isCalibrationActive = false;
+
+        public bool IsCalibrationActive { get => isCalibrationActive; set => isCalibrationActive = value; }
+
+        private HPUIInteractor interactor;
+        private HPUIFullRangeRayCastDetectionLogic fullRayDetectionLogic;
+        private HPUIInteractorFullRangeAngles fullRangeAngles;
+        private List<InteractionDataRecord> interactionRecords = new();
+        private List<List<HPUIRayCastDetectionBaseLogic.RaycastDataRecord>> currentInteractionData = new();
+
+        public ConeRayAnglesCalibrator(HPUIInteractor interactor)
+        {
+
+            if (!(interactor.DetectionLogic is HPUIFullRangeRayCastDetectionLogic fullRayDetectionLogic))
+            {
+                throw new ArgumentException("Interactor is expected to have `HPUIFullRangeRayCastDetectionLogic` as the DetectionLogic.");
+            }
+            this.interactor = interactor;
+            this.fullRayDetectionLogic = fullRayDetectionLogic;
+            this.fullRangeAngles = fullRayDetectionLogic.FullRangeRayAngles;
+
+            fullRayDetectionLogic.raycastData += RaycastDataCallback;
+        }
+
+        /// <summary>
+        /// The callback used to get the data from the <see cref="HPUIFullRangeRayCastDetectionLogic.raycastData"/>.
+        /// </summary>
+        protected void RaycastDataCallback(List<HPUIRayCastDetectionBaseLogic.RaycastDataRecord> raycastDataRecords)
+        {
+            // ensuring the provided interactor is the same as the one providing the callbacks.
+            if (!isCalibrationActive) return;
+            Assert.AreEqual(fullRangeAngles, ((HPUIFullRangeRayCastDetectionLogic)interactor.DetectionLogic).FullRangeRayAngles, $"Interactor {fullRangeAngles.name} is not the same as {((HPUIFullRangeRayCastDetectionLogic)interactor.DetectionLogic).FullRangeRayAngles.name}");
+            if (raycastDataRecords.Count > 0)
+            {
+                currentInteractionData.Add(raycastDataRecords);
+            }
+        }
+
+        /// <summary>
+        /// The callback used with the interactable gesture event to track the events.
+        /// </summary>
+        public void EndCalibrationForSegment(HPUIInteractorConeRayAngleSegment segment)
+        {
+            interactionRecords.Add(new InteractionDataRecord(currentInteractionData, segment));
+
+            currentInteractionData = new();
+        }
+
+        /// <summary>
+        /// Stops the data collection and initates the estimation. Once done, callback will be invoked with the estimated asset.
+        /// </summary>
+        /// <remarks>
+        /// This will unsubscribe to <see cref="HPUIInteractor.DetectionLogic"/>interactor.DetectionLogic</see>
+        /// and the <see cref="IHPUIInteractable.GestureEvent">GestureEvent</see> of each
+        /// interactable it is tracking.
+        /// </remarks>
+        public void EstimateConeRayAngles(Action<HPUIInteractorConeRayAngles> callback)
+        {
+            HPUIInteractorConeRayAngles estimatedConeRayAngles = ScriptableObject.CreateInstance<HPUIInteractorConeRayAngles>();
+
+            fullRayDetectionLogic.raycastData -= RaycastDataCallback;
+
+            interactor.StartCoroutine(EstimationCoroutine(callback, estimatedConeRayAngles));
+        }
+
+        /// <summary>
+        /// Coroutine that does the actual work of <see cref="EstimateConeRayAngles"/>.
+        /// </summary>
+        protected IEnumerator EstimationCoroutine(Action<HPUIInteractorConeRayAngles> callback, HPUIInteractorConeRayAngles estimatedConeRayAngles)
+        {
+            yield return null;
+            HPUIInteractorConeRayAngleSegment[] segments = (HPUIInteractorConeRayAngleSegment[])Enum.GetValues(typeof(HPUIInteractorConeRayAngleSegment));
+
+            Task<List<HPUIInteractorRayAngle>>[] tasks = new Task<List<HPUIInteractorRayAngle>>[segments.Length];
+
+            int i = 0;
+            foreach (HPUIInteractorConeRayAngleSegment segment in segments)
+            {
+                tasks[i++] = Task.Run(() => EstimateConeAnglesForSegment(segment, interactionRecords));
+            }
+
+            while (tasks.Any(t => !t.IsCompleted))
+            {
+                IEnumerable<Exception> exceptions = tasks.Select(t => t.Exception).Where(t => t != null);
+                if (exceptions.Count() != 0)
+                {
+                    // Throwing the first thing that comes through.
+                    // MAYBE: Should all of them be processed somehow?
+                    throw exceptions.First();
+                }
+                yield return null;
+            }
+
+            for (i = 0; i < segments.Length; ++i)
+            {
+                HPUIInteractorConeRayAngleSegment segment = segments[i];
+                List<HPUIInteractorRayAngle> coneAnglesForSegment = tasks[i].Result;
+                switch (segment)
+                {
+                    case HPUIInteractorConeRayAngleSegment.IndexDistalSegment:
+                        estimatedConeRayAngles.IndexDistalAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.IndexIntermediateSegment:
+                        estimatedConeRayAngles.IndexIntermediateAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.IndexProximalSegment:
+                        estimatedConeRayAngles.IndexProximalAngles = coneAnglesForSegment;
+                        break;
+
+                    case HPUIInteractorConeRayAngleSegment.MiddleDistalSegment:
+                        estimatedConeRayAngles.MiddleDistalAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.MiddleIntermediateSegment:
+                        estimatedConeRayAngles.MiddleIntermediateAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.MiddleProximalSegment:
+                        estimatedConeRayAngles.MiddleProximalAngles = coneAnglesForSegment;
+                        break;
+
+                    case HPUIInteractorConeRayAngleSegment.RingDistalSegment:
+                        estimatedConeRayAngles.RingDistalAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.RingIntermediateSegment:
+                        estimatedConeRayAngles.RingIntermediateAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.RingProximalSegment:
+                        estimatedConeRayAngles.RingProximalAngles = coneAnglesForSegment;
+                        break;
+
+                    case HPUIInteractorConeRayAngleSegment.LittleDistalSegment:
+                        estimatedConeRayAngles.LittleDistalAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.LittleIntermediateSegment:
+                        estimatedConeRayAngles.LittleIntermediateAngles = coneAnglesForSegment;
+                        break;
+                    case HPUIInteractorConeRayAngleSegment.LittleProximalSegment:
+                        estimatedConeRayAngles.LittleProximalAngles = coneAnglesForSegment;
+                        break;
+                }
+            }
+
+            try
+            {
+                callback.Invoke(estimatedConeRayAngles);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"{e}");
+            }
+        }
+
+        /// <summary>
+        /// For a given segment, computes the List of <see cref="HPUIInteractorRayAngle">.
+        /// </summary>
+        /// <param name="segment">
+        ///   The <see cref="HPUIInteractorConeRayAngleSegment"/> for which cone
+        ///   angles are being computed.
+        /// </param>
+        /// <param name="interactionRecords">
+        ///   Each <see cref="InteractionDataRecord"/> in the list is expected to be the data collected during a single gesture event.
+        ///   The <see cref="InteractionDataRecord.segment">segment</see> of each record will be based on the interactableSegmentPairs
+        ///   passed in the constructor.
+        /// </param>
+        /// <param name="interactableSegmentPairs">
+        ///   The interactableSegmentPairs passed in the constructor.
+        /// </param>
+        protected virtual List<HPUIInteractorRayAngle> EstimateConeAnglesForSegment(HPUIInteractorConeRayAngleSegment segment, List<InteractionDataRecord> interactionRecords)
+        {
+            Dictionary<(float, float), float> averageRayDistance = new();
+            // For each interaction, get the frame with the shortest distance
+            foreach (InteractionDataRecord interactionRecord in interactionRecords)
+            {
+                if (interactionRecord.segment == segment)
+                {
+                    // Collect all the distances for a given ray
+                    Dictionary<(float, float), List<float>> rayDistances = new();
+                    // for each frame in all the frames collected in a gesture
+                    foreach (var frame in interactionRecord.records)
+                    {
+                        // for each ray in a given frame
+                        foreach (var ray in frame)
+                        {
+                            // if a list hasn't been created for a ray
+                            // i.e. this is the first time the ray is interacting
+                            // in this gesture
+                            if (!rayDistances.ContainsKey((ray.angleX, ray.angleZ)))
+                            {
+                                rayDistances[(ray.angleX, ray.angleZ)] = new List<float>();
+                            }
+                            // add the ray to the list
+                            rayDistances[(ray.angleX, ray.angleZ)].Add(ray.distance);
+                        }
+                    }
+
+                    foreach (var ray in rayDistances)
+                    {
+                        if (ray.Value.Count > 10) //TODO: Remove magic number!
+                        {
+                            averageRayDistance[(ray.Key.Item1, ray.Key.Item2)] = ray.Value.Average();
+                        }
+                    }
+                }
+            }
+
+            if (averageRayDistance.Count() == 0)
+            {
+                return new List<HPUIInteractorRayAngle>();
+            }
+            List<HPUIInteractorRayAngle> coneAnglesForSegment = new();
+
+            foreach (var ray in averageRayDistance)
+            {
+                coneAnglesForSegment.Add(new HPUIInteractorRayAngle(ray.Key.Item1, ray.Key.Item2, ray.Value));
+            }
+
+            return coneAnglesForSegment;
+        }
+
+        /// <summary>
+        /// Holds all the data collected for a single calibration event.
+        /// </summary>
+        protected struct InteractionDataRecord
+        {
+            // the frames captured, where each frame contains all the rays with data in that frame
+            // see <see cref="HPUIRayCastDetectionBaseLogic.RaycastDataRecord"/> for more info
+            public List<List<HPUIRayCastDetectionBaseLogic.RaycastDataRecord>> records;
+            // the segment for which the calibration is being performed
+            public HPUIInteractorConeRayAngleSegment segment;
+
+            public InteractionDataRecord(List<List<HPUIRayCastDetectionBaseLogic.RaycastDataRecord>> records, HPUIInteractorConeRayAngleSegment segment) : this()
+            {
+                this.records = records;
+                this.segment = segment;
+            }
+        }
+    }
+}

--- a/Runtime/Components/ConeRayAnglesCalibrator.cs.meta
+++ b/Runtime/Components/ConeRayAnglesCalibrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ece2092b896d074791341fe8bddd427


### PR DESCRIPTION
This first commit provides a new way of estimating the cone by averaging multiple calibration frames from the user making a rubbing motion over each of the phalanges.

Yes this implementation is a horrible way to go about it, like 80% of the code is yoinked from 

- `ConeRayAnglesEstimationRoutine`
- `ConeRayAnglesEstimatior`
- `EstimateConeRayAnglesEditor` (which should have been renamed to `ConeRayAnglesEstimationRoutineEditor` with the previous PR, sorry about that)

to produce

- `ConeRayAnglesCalibrationRoutine`
- `ConeRayAnglesCalibrator`
- `ConeRayAnglesCalibrationRoutineEditor`

respectively

This PR is more to figure out a way to generalize this personalization process. We want to account for an open-ended system where we can bind any phalange to any `List<List<HPUIRayCastDetectionBaseLogic.RaycastDataRecord>>` (the frames of data recorded).
This might mean having rubbing motions for a full finger, or just the tap based approach like we currently have.
This also means disassociating the interactable from the segment, or making it optional to reduce overhead when performing the calibration.

Another thing we want to account for (which technically `EstimateConeAnglesForSegment` accounts for by being virtual) is different cone production strategies. Stuff like using the average (as is in this case) or means, or maybe even a pre-processing function which uses other heuristics (such as the mean distance of the thumb from the phalange throughout the interaction, and removing all frames where that's 3sds away from that phalange, etc)

Not fully sure how to structure this piece, not even sure if we want to spend a lot of effort in making it too modular. Lemmino how we should go about this. Rip and tear into this as you wish :D