### PR TITLE
fixed bug in data records being passed for cone ray segment computation

### DIFF
--- a/Runtime/Components/ConeRayAnglesEstimator/ConeRayEstimator.cs
+++ b/Runtime/Components/ConeRayAnglesEstimator/ConeRayEstimator.cs
@@ -190,8 +190,7 @@ namespace ubco.ovilab.HPUI
             int i = 0;
             foreach (HPUIInteractorConeRayAngleSegment segment in segments)
             {
-                IEnumerable<ConeRayComputationDataRecord> filteredDataRecords = dataRecords.Where(r => r.segment == segment);
-                tasks[i++] = Task.Run(() => coneRaySegmentComputation.EstimateConeAnglesForSegment(segment, filteredDataRecords));
+                tasks[i++] = Task.Run(() => coneRaySegmentComputation.EstimateConeAnglesForSegment(segment, dataRecords));
             }
 
             while (tasks.Any(t => !t.IsCompleted))


### PR DESCRIPTION
the parallelization was doing something weird with the linq being run for the filtered data records. Both peak and average functions already perform filtering implicitly via
`if (interactionRecord.segment == segment) ...`

Doing this was causing the same collection of raycast records to be sent to all the tasks for some reason
