### PR TITLE
fix incorrect calibration warnings

### DIFF
--- a/Runtime/Components/ConeRayAnglesEstimator/NthPercentileConeRaySegmnetComputation.cs
+++ b/Runtime/Components/ConeRayAnglesEstimator/NthPercentileConeRaySegmnetComputation.cs
@@ -48,20 +48,22 @@ namespace ubco.ovilab.HPUI
                         }
                     }
                     int frameCountForMinRayInteractionsThreshold = (int)(minRayInteractionsThreshold * interactionRecord.records.Count);
+                    bool atLeastOneRayAnalyzed = false;
                     foreach (var ray in rayDistances)
                     {
+                        atLeastOneRayAnalyzed = true;
                         if (ray.Value.Count > frameCountForMinRayInteractionsThreshold)
                         {
                             averageRayDistance[(ray.Key.Item1, ray.Key.Item2)] = ray.Value.Percentile(percentile);
                         }
                     }
+                    if (atLeastOneRayAnalyzed && averageRayDistance.Count() == 0)
+                    {
+                        Debug.LogWarning($"Data collection has gone wrong for Phalange {segment.ToString()}, no rays have been utilized enough for ray interaction threshold of {minRayInteractionsThreshold}");
+                    }
                 }
             }
 
-            if (averageRayDistance.Count() == 0)
-            {
-                Debug.LogWarning($"Data collection has gone wrong for Phalange {segment.ToString()}, no rays have been utilized enough for ray interaction threshold of {minRayInteractionsThreshold}");
-            }
 
             List<HPUIInteractorRayAngle> coneAnglesForSegment = new();
 

--- a/Runtime/Components/ConeRayAnglesEstimator/NthPercentileConeRaySegmnetComputation.cs
+++ b/Runtime/Components/ConeRayAnglesEstimator/NthPercentileConeRaySegmnetComputation.cs
@@ -24,6 +24,8 @@ namespace ubco.ovilab.HPUI
         {
             Dictionary<(float, float), float> averageRayDistance = new();
             // For each interaction, get the frame with the shortest distance
+            bool atLeastOneRayAnalyzed = false;
+
             foreach (ConeRayComputationDataRecord interactionRecord in interactionRecords)
             {
                 if (interactionRecord.segment == segment)
@@ -48,7 +50,6 @@ namespace ubco.ovilab.HPUI
                         }
                     }
                     int frameCountForMinRayInteractionsThreshold = (int)(minRayInteractionsThreshold * interactionRecord.records.Count);
-                    bool atLeastOneRayAnalyzed = false;
                     foreach (var ray in rayDistances)
                     {
                         atLeastOneRayAnalyzed = true;
@@ -57,13 +58,13 @@ namespace ubco.ovilab.HPUI
                             averageRayDistance[(ray.Key.Item1, ray.Key.Item2)] = ray.Value.Percentile(percentile);
                         }
                     }
-                    if (atLeastOneRayAnalyzed && averageRayDistance.Count() == 0)
-                    {
-                        Debug.LogWarning($"Data collection has gone wrong for Phalange {segment.ToString()}, no rays have been utilized enough for ray interaction threshold of {minRayInteractionsThreshold}");
-                    }
                 }
             }
 
+            if (atLeastOneRayAnalyzed && averageRayDistance.Count() == 0)
+            {
+                Debug.LogWarning($"Data collection has gone wrong for Phalange {segment.ToString()}, no rays have been utilized enough for ray interaction threshold of {minRayInteractionsThreshold}");
+            }
 
             List<HPUIInteractorRayAngle> coneAnglesForSegment = new();
 


### PR DESCRIPTION
the warnings produced were happening for phalanges which were not calibrated for, and misattributing it to the minimum ray interaction threshold. We already have the editor warning for phalanges which haven't received any data during the calibration phase. If no data was collected for a phalange at all, then the "calibration went wrong" shouldn't be fired. This PR fixes that by ensuring at least one frame with one ray interacted with the relevant phalange before complaining about calibration going incorrect on account of min ray interaction threshold's requirement.