### PR TITLE
Add ray culling by distance to centroid

### DIFF
--- a/Editor/Components/StatisticalConeRaySegmentComputationDrawer.cs
+++ b/Editor/Components/StatisticalConeRaySegmentComputationDrawer.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEditor;
-using ubco.ovilab.HPUI;
 
 namespace ubco.ovilab.HPUI.Editor
 {
@@ -9,7 +8,7 @@ namespace ubco.ovilab.HPUI.Editor
     {
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            int lines = 4;
+            int lines = 6;
 
             // Show percentile only if EstimateTechnique is Percentile
             SerializedProperty estimateTechniqueProp = property.FindPropertyRelative("estimateTechnique");
@@ -32,6 +31,9 @@ namespace ubco.ovilab.HPUI.Editor
             SerializedProperty percentileProp = property.FindPropertyRelative("percentile");
             SerializedProperty multiplierProp = property.FindPropertyRelative("multiplier");
 
+            SerializedProperty cullRaysByDistanceToCentroidProp = property.FindPropertyRelative("cullRaysByDistanceToCentroid");
+            SerializedProperty cullingDistanceThresholdNormalizedProp = property.FindPropertyRelative("cullingDistanceThresholdNormalized");
+
             lineRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
             EditorGUI.PropertyField(lineRect, estimateTechniqueProp);
 
@@ -47,6 +49,14 @@ namespace ubco.ovilab.HPUI.Editor
 
             lineRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
             EditorGUI.PropertyField(lineRect, multiplierProp);
+
+            lineRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            EditorGUI.PropertyField(lineRect, cullRaysByDistanceToCentroidProp);
+
+            GUI.enabled = cullRaysByDistanceToCentroidProp.boolValue;
+            lineRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            EditorGUI.PropertyField(lineRect, cullingDistanceThresholdNormalizedProp);
+            GUI.enabled = true;
 
             EditorGUI.EndProperty();
         }


### PR DESCRIPTION
Add distance-based culling to StatisticalConeRaySegmentComputation and expose controls in its Editor drawer. This implements a configurable filter that removes rays based on their angular proximity to the cluster centroid, allowing the cone to ignore outlier rays and tighten the estimated cone.

What happens:
- After computing per-ray distances, when culling is enabled compute a simple centroid direction (sum of normalized directions) and map each ray to its projection (dot) on the centroid. Compute a threshold based on the min/max projection and the normalized culling parameter, and filter rays below it.
- Note: the centroid computation is intentionally simple (KLUDGE comment); it can be improved later to a Riemannian/Karcher mean if needed.

cc: @ThatAmuzak @omangbaheti if you can test this with what's on #44 