### PR TITLE
bursting mesh continuous colliders manager

### DIFF
--- a/Runtime/Interaction/MeshContinuousCollidersManager.cs
+++ b/Runtime/Interaction/MeshContinuousCollidersManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
@@ -157,6 +158,7 @@ namespace ubco.ovilab.HPUI.Interaction
             return coordsForCol;
         }
 
+        [BurstCompile]
         protected void UpdateColliderPositions()
         {
             mesh.BakeMesh(tempMesh, true);
@@ -180,6 +182,7 @@ namespace ubco.ovilab.HPUI.Interaction
         }
 
         struct DeformedCollidersJob: IJobParallelForTransform
+        [BurstCompile]
         {
             private Vector3 right, forward, temppos;
             public float ScaleFactor, GridSize;


### PR DESCRIPTION
gives a nice 10-15 fps boost overall
could probably be improved with the use of mathematics datatypes like float3 instead of Vector3, let me know if that's worth implementing